### PR TITLE
Remove extra space in command flags

### DIFF
--- a/StackOverflow/stackoverflow.yml
+++ b/StackOverflow/stackoverflow.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '14'
       - name: Get Questions & Add to Orbit
-        run: npx @orbit-love/stackoverflow --questions --answers --hours=1 --tag= "${{matrix.tag}}"
+        run: npx @orbit-love/stackoverflow --questions --answers --hours=1 --tag="${{matrix.tag}}"
         env:
           ORBIT_WORKSPACE_ID: ${{ secrets.ORBIT_WORKSPACE_ID }}
           ORBIT_API_KEY: ${{ secrets.ORBIT_API_KEY }}


### PR DESCRIPTION
The space in the `run` command causes this to not work. Removing the space makes it work!

* [x] The template is in a sub-folder named for the integration
* [x] You have added a summary of the integration to the main README.md for this repository
* [x] The sub-folder has an `README.md` file with clear steps on how to use it
* [x] The integration uses the following environment variable names for the Orbit credentials: `ORBIT_WORKSPACE_ID` and `ORBIT_API_KEY`
