### PR TITLE
Prevent accidental reddit activity import

### DIFF
--- a/Reddit/README.md
+++ b/Reddit/README.md
@@ -12,7 +12,7 @@ This integration runs every hour and checks for new posts and comments in a spec
 1. Go to your repository created during your [first-time setup](../FIRST_TIME_SETUP.md) and click on the Actions tab.
 2. Click "set up a workflow yourself" and call it reddit.yml - delete the content so it is blank.
 3. Copy the contents of [reddit.yml](reddit.yml) into your new workflow.
-4. At a minimum, replace line 12 and 13 with at least one subreddit. Then uncomment this section in order for the workflow to work. Make sure to do replace the default values, otherwise you will be **importing activity from these subreddits.**
+4. At a minimum, replace line 12 and 13 with at least one subreddit. Then uncomment this section in order for the workflow to work. Make sure to replace the default values, otherwise you will be **importing activity from these subreddits.**
 5. This automation requires credentials from Reddit to be added to your GitHub repository secrets.
 
    1. Head to your [Reddit App Preferences](https://www.reddit.com/prefs/apps/).

--- a/Reddit/README.md
+++ b/Reddit/README.md
@@ -12,8 +12,8 @@ This integration runs every hour and checks for new posts and comments in a spec
 1. Go to your repository created during your [first-time setup](../FIRST_TIME_SETUP.md) and click on the Actions tab.
 2. Click "set up a workflow yourself" and call it reddit.yml - delete the content so it is blank.
 3. Copy the contents of [reddit.yml](reddit.yml) into your new workflow.
-4. Edit the items underneath line 11 to add your subreddits to watch.
-5. This automation requires credentials from Reddit to be added to your GitHub repository secrets.\*
+4. At a minimum, replace line 12 and 13 with at least one subreddit. Then uncomment this section in order for the workflow to work. Make sure to do replace the default values, otherwise you will be **importing activity from these subreddits.**
+5. This automation requires credentials from Reddit to be added to your GitHub repository secrets.
 
    1. Head to your [Reddit App Preferences](https://www.reddit.com/prefs/apps/).
    2. Create a new app with the following settings:
@@ -25,14 +25,10 @@ This integration runs every hour and checks for new posts and comments in a spec
    3. Take note of your `Client ID` which is just below your app name, and your `Client Secret`.
    4. Follow the steps in the [GitHub Actions Templates First Time Setup Guide](https://github.com/orbit-love/github-actions-templates/blob/main/FIRST_TIME_SETUP.md) and add `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, and `REDDIT_PASSWORD` values.
 
-\*PLEASE NOTE: For this to work, your Reddit account should have 2FA _disabled_ AND needs to have a passwords set.
+**PLEASE NOTE:** For this to work, your Reddit account should have 2FA _disabled_ AND needs to have a passwords set.
 
-- If you used your Google or Apple account to sign up to Reddit and don't have an account you can disconnect it and then you'll be able to set an account (an reconnect your Google or Apple account after).
-- If you want to have 2FA enabled on your main Reddit account (you probably should): create an additional acocunt to just set up this integration and don't use your main account.
-
-PLEASE NOTE: For this to work, your Reddit account should have 2FA *disabled* AND needs to have a passwords set.
-- If you used your Google or Apple account to sign up to Reddit and don't have an account you can disconnect it and then you'll be able to set an account (an reconnect your Google or Apple account after).
-- If you want to have 2FA enabled on your main Reddit account (you probably should): create an additional acocunt to just set up this integration and don't use your main account.
+- If you used your Google or Apple account to sign up to Reddit and don't have an account you can disconnect it and then you'll be able to set an account (and reconnect your Google or Apple account after).
+- If you want to have 2FA enabled on your main Reddit account (you probably should): create an additional account to just set up this integration and don't use your main account.
 
 ### Filtering Posts & Comments
 

--- a/Reddit/reddit.yml
+++ b/Reddit/reddit.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        subreddit:
-          - javascript
-          - vuejs
+#        subreddit:
+#          - javascript
+#          - vue
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js


### PR DESCRIPTION
* [x] The template is in a sub-folder named for the integration
* [x] You have added a summary of the integration to the main README.md for this repository
* [x] The sub-folder has an `README.md` file with clear steps on how to use it
* [x] The integration uses the following environment variable names for the Orbit credentials: `ORBIT_WORKSPACE_ID` and `ORBIT_API_KEY`

This is modifying the existing Reddit action.

## Problem

By default, if this template is used and you forget to modify the preset subreddit list, you will accidentally import activity from those subreddits. 

## Solution

This modification forces the implementation to need to uncomment the subreddit lines when ready, otherwise the workflow will fail. I figured it would be better to fail instead of have an accidental activity import to Orbit, resulting in needing to delete activity (I may have done this :sweat_smile: )

Directions have been updated with this information, along with removal of duplicate README content.